### PR TITLE
A few packaging improvements

### DIFF
--- a/rocm-hip.spec
+++ b/rocm-hip.spec
@@ -158,8 +158,8 @@ cd build
 %files
 %doc README.md
 %license LICENSE.txt
-# FIXME: hipInfo shouldn't be hidden, nor in libdir:
-%{_libdir}/.hipInfo
+# This is not needed, and debian excludes it too:
+%exclude %{_libdir}/.hipInfo
 %{_libdir}/libamdhip64.so.5{,.*}
 %{_libdir}/libhiprtc.so.5{,.*}
 %{_libdir}/libhiprtc-builtins.so.5{,.*}

--- a/rocm-hip.spec
+++ b/rocm-hip.spec
@@ -91,7 +91,8 @@ The AMD ROCm HIP development package.
 
 %package samples
 Summary:        ROCm HIP samples
-Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
+BuildArch:      noarch
 
 %description samples
 The AMD ROCm HIP samples.

--- a/rocm-hip.spec
+++ b/rocm-hip.spec
@@ -112,6 +112,11 @@ sed -e "/CMAKE_INSTALL_RPATH.*CMAKE_INSTALL_LIBDIR/d" \
     -e "/CMAKE_INSTALL_RPATH_USE_LINK_PATH.*TRUE/d" \
     -i CMakeLists.txt
 
+# Fix script permissions:
+chmod 755 ../HIP-rocm-%{version}/bin/*
+# FIXME: perl module files should be installed into lib or share:
+chmod 644 ../HIP-rocm-%{version}/bin/*.pm
+
 # Unpack bundled sources manually
 cd ..
 gzip -dc %{SOURCE2} | tar -xof -


### PR DESCRIPTION
As I mentioned in another thread, hipinfo shouldn't be necessary, and installing data files into libdir is counter to Fedora's FHS policy. You can discard the commit if you wish, but for strictness, if we're going to try to get this into Fedora proper, I would suggest discarding it for now.

I noticed rpmlint complains about a few other files, but they cannot be discarded as far as I know:
rocm-hip-devel.x86_64: E: script-without-shebang /usr/bin/.hipVersion
rocm-hip-devel.x86_64: E: script-without-shebang /usr/bin/hipvars.pm
rocm-hip-devel.x86_64: W: non-executable-in-bin /usr/bin/.hipVersion 644
rocm-hip-devel.x86_64: W: non-executable-in-bin /usr/bin/hipvars.pm 664

@cgmb was working with Debian to resolve these, but he might not be available to provide input right now. He might be a better contact for hipcc related issues. I believe he works on a lot of the HIP libraries needed for applications such as pytorch.

Also, the samples package should be noarch since it's just source code. I noticed rpmlint still warns about these files, e.g.:

rocm-hip-samples.noarch: W: devel-file-in-non-devel-package /usr/share/hip/samples/0_Intro/bit_extract/bit_extract.cpp
rocm-hip-samples.noarch: W: devel-file-in-non-devel-package /usr/share/hip/samples/0_Intro/module_api/defaultDriver.cpp
... etc.

But I feel like this is a false positive and can be ignored.

I was speaking to upstream and it seems like they want to merge all of the source into a single repo (hipamd, rocclr, opencl), so maybe in the longterm we can merge the hip package into Fedora's rocm-opencl, or add a new parent package and make opencl and hip subpackages.